### PR TITLE
Fix the title of the benchmarks

### DIFF
--- a/rocPRISM/scan.cu
+++ b/rocPRISM/scan.cu
@@ -8,7 +8,7 @@
  */
 
 /*! @file
- * @brief Radix-sort performance test
+ * @brief Scan performance test
  *
  * @author Sebastian Keller <sebastian.f.keller@gmail.com>
  */


### PR DESCRIPTION
Is there a reason why the values are not generated on the full 64 bit range here? https://github.com/eth-cscs/amd-gpu-benchmarks/compare/fix_titles?expand=1#diff-a990126a7feac0630ad3e2891b84a916d94553ec4b0267ebdc5c8fa75cb193b6R36