### PR TITLE
Add memory tracking allocator

### DIFF
--- a/rocPRISM/memory_tracking_allocator.cuh
+++ b/rocPRISM/memory_tracking_allocator.cuh
@@ -1,0 +1,64 @@
+/*
+ * AMD-GPU benchmarks
+ *
+ * Copyright (c) 2025 CSCS, ETH Zurich
+ *
+ * Please, refer to the LICENSE file in the root directory.
+ * SPDX-License-Identifier: MIT License
+ */
+
+#pragma once
+
+#include <cstdio>
+#include <atomic>
+#include <thrust/device_malloc.h>
+#include <thrust/device_free.h>
+#include <thrust/mr/memory_resource.h>
+#include <thrust/mr/allocator.h>
+
+class tracking_mr final : public thrust::mr::memory_resource<>
+{
+    std::atomic<std::size_t> current_bytes{0};
+    std::atomic<std::size_t> peak_bytes{0};
+    std::atomic<std::size_t> total_bytes{0};
+    std::atomic<std::size_t> num_allocs{0};
+
+public:
+    // default thrust alignment is used
+    virtual void* do_allocate(std::size_t bytes, std::size_t) override
+    {
+        thrust::device_ptr<uint8_t> ptr = thrust::device_malloc<uint8_t>(bytes);
+        if (!ptr.get()) throw std::bad_alloc();
+
+        std::size_t current = current_bytes.fetch_add(bytes) + bytes;
+        total_bytes.fetch_add(bytes);
+        num_allocs.fetch_add(1);
+
+        std::size_t peak = peak_bytes.load();
+        while (current > peak && !peak_bytes.compare_exchange_weak(peak, current));
+
+        return static_cast<void*>(ptr.get());
+    }
+
+    virtual void do_deallocate(void* ptr, std::size_t bytes, std::size_t) override
+    {
+        current_bytes.fetch_sub(bytes);
+        thrust::device_free(thrust::device_ptr<uint8_t>(static_cast<uint8_t*>(ptr)));
+    }
+
+    void reset()
+    {
+        current_bytes.store(0);
+        peak_bytes.store(0);
+        total_bytes.store(0);
+        num_allocs.store(0);
+    }
+
+    void print_stats() const
+    {
+        std::printf("Memory statistics:\n");
+        std::printf("  Total allocated: %f MiB\n", total_bytes.load() / (1024.0 * 1024.0));
+        std::printf("  Peak allocated: %f MiB\n", peak_bytes.load() / (1024.0 * 1024.0));
+        std::printf("  Number of allocations: %zu\n", num_allocs.load());
+    }
+};

--- a/rocPRISM/reduce.cu
+++ b/rocPRISM/reduce.cu
@@ -1,20 +1,18 @@
 /*
  * AMD-GPU benchmarks
  *
- * Copyright (c) 2024 CSCS, ETH Zurich
+ * Copyright (c) 2025 CSCS, ETH Zurich
  *
  * Please, refer to the LICENSE file in the root directory.
  * SPDX-License-Identifier: MIT License
  */
 
 /*! @file
- * @brief Radix-sort performance test
- *
- * @author Sebastian Keller <sebastian.f.keller@gmail.com>
+ * @brief Reduction performance test with memory tracking
  */
 
 #include <algorithm>
-#include <iostream>
+#include <cstdio>
 #include <numeric>
 #include <random>
 
@@ -22,6 +20,7 @@
 #include <thrust/reduce.h>
 
 #include "timing.cuh"
+#include "memory_tracking_allocator.cuh"
 
 int main(int argc, char** argv)
 {
@@ -37,24 +36,48 @@ int main(int argc, char** argv)
         std::generate(hostValues.begin(), hostValues.end(), [&](){ return dist(gen); });
     }
 
-    thrust::device_vector<ValueType>   values = hostValues;
+    thrust::device_vector<ValueType> values = hostValues;
 
-    auto reduce = [&]()
+    tracking_mr memory_tracker;
+    thrust::mr::allocator<ValueType, tracking_mr> alloc(&memory_tracker);
+
+    auto reduceNormal = [&]()
     {
-        return thrust::reduce(values.begin(), values.end());
+#ifdef __HIP__
+        return thrust::reduce(thrust::hip::par, values.begin(), values.end());
+#else
+        return thrust::reduce(thrust::cuda::par, values.begin(), values.end());
+#endif
     };
 
-    auto deviceResult = reduce(); // warmup
-    float t_reduce    = timeGpu(reduce);
+    auto reduceTracked = [&]()
+    {
+#ifdef __HIP__
+        return thrust::reduce(thrust::hip::par(alloc), values.begin(), values.end());
+#else
+        return thrust::reduce(thrust::cuda::par(alloc), values.begin(), values.end());
+#endif
+    };
 
+    auto deviceResult = reduceNormal();
+    float timeReduce = timeGpu(reduceNormal);    // to compare with memory tracking time
+
+    auto deviceResultTracked = reduceTracked();
+    memory_tracker.reset();
+    float timeReduceTracked = timeGpu(reduceTracked);
+
+    memory_tracker.print_stats();
     std::size_t numBytesMoved = numValues * sizeof(ValueType);
-    std::cout << "reduction time for " << numValues << " values: " << t_reduce / 1000 << " s"
-        << ", bandwidth: " << float(numBytesMoved) / t_reduce / 1000 << " MiB/s" << std::endl;
+    std::printf("reduction normal time for %zu values: %f s, bandwidth: %f MiB/s\n",
+                numValues, timeReduce / 1000, float(numBytesMoved) / timeReduce / 1000);
+    std::printf("reduction with memory tracking time for %zu values: %f s, bandwidth: %f MiB/s\n",
+            numValues, timeReduceTracked / 1000, float(numBytesMoved) / timeReduceTracked / 1000);
 
     if (power <= 25)
     {
         auto hostResult = std::accumulate(hostValues.begin(), hostValues.end(), ValueType(0));
-        std::cout << "GPU matches CPU: " << (deviceResult == hostResult ? "PASS" : "FAIL") << std::endl;
+        std::printf("CPU matches GPU: %s\n", (deviceResult == hostResult ? "PASS" : "FAIL"));
+        std::printf("GPU normal matches GPU with tracked memory: %s\n", (deviceResult == deviceResultTracked ? "PASS" : "FAIL"));
     }
 
     return 0;


### PR DESCRIPTION
This updated reduce test has the following output:
```
Memory statistics:
  Total allocated: 0.062531 MiB
  Peak allocated: 0.062531 MiB
  Number of allocations: 1
reduction normal time for 33554432 values: 0.000268 s, bandwidth: 1001019.687500 MiB/s
reduction with memory tracking time for 33554432 values: 0.000258 s, bandwidth: 1040762.187500 MiB/s
CPU matches GPU: PASS
GPU normal matches GPU with tracked memory: PASS
```
I've only adapted reduce to use the custom allocator for now, and will update the others after a review of the PR.