### PR TITLE
Include input vector allocation in the memory tracking

### DIFF
--- a/parallel_algos/memory_tracking_allocator.cuh
+++ b/parallel_algos/memory_tracking_allocator.cuh
@@ -13,10 +13,11 @@
 #include <cstdio>
 #include <thrust/device_free.h>
 #include <thrust/device_malloc.h>
+#include <thrust/device_vector.h>
 #include <thrust/mr/allocator.h>
 #include <thrust/mr/memory_resource.h>
 
-class tracking_mr final : public thrust::mr::memory_resource<>
+class tracking_mr final : public thrust::mr::memory_resource<thrust::device_ptr<void>>
 {
     std::atomic<std::size_t> current_bytes{0};
     std::atomic<std::size_t> peak_bytes{0};
@@ -24,10 +25,16 @@ class tracking_mr final : public thrust::mr::memory_resource<>
     std::atomic<std::size_t> num_allocs{0};
 
 public:
+    template <typename T>
+    using allocator = thrust::mr::allocator<T, tracking_mr>;
+
+    template <typename T>
+    using vector = thrust::device_vector<T, allocator<T>>;
+
     // default thrust alignment is used
-    virtual void* do_allocate(std::size_t bytes, std::size_t) override
+    thrust::device_ptr<void> do_allocate(std::size_t bytes, std::size_t) override
     {
-        thrust::device_ptr<uint8_t> ptr = thrust::device_malloc<uint8_t>(bytes);
+        thrust::device_ptr<void> ptr = thrust::device_malloc<uint8_t>(bytes);
         if (!ptr.get()) throw std::bad_alloc();
 
         std::size_t current = current_bytes.fetch_add(bytes) + bytes;
@@ -38,13 +45,13 @@ public:
         while (current > peak && !peak_bytes.compare_exchange_weak(peak, current))
             ;
 
-        return static_cast<void*>(ptr.get());
+        return ptr;
     }
 
-    virtual void do_deallocate(void* ptr, std::size_t bytes, std::size_t) override
+    void do_deallocate(thrust::device_ptr<void> ptr, std::size_t bytes, std::size_t) override
     {
         current_bytes.fetch_sub(bytes);
-        thrust::device_free(thrust::device_ptr<uint8_t>(static_cast<uint8_t*>(ptr)));
+        thrust::device_free(ptr);
     }
 
     void reset()
@@ -55,9 +62,10 @@ public:
         num_allocs.store(0);
     }
 
+    template <bool IsTemporary>
     void print_stats() const
     {
-        std::printf("Memory statistics:\n");
+        std::printf("%s memory statistics:\n", IsTemporary ? "Temporary" : "Input/Output");
         std::printf("  Total allocated: %f MiB\n", total_bytes.load() / (1024.0 * 1024.0));
         std::printf("  Peak allocated: %f MiB\n", peak_bytes.load() / (1024.0 * 1024.0));
         std::printf("  Number of allocations: %zu\n", num_allocs.load());

--- a/parallel_algos/radix-sort.cu
+++ b/parallel_algos/radix-sort.cu
@@ -40,12 +40,16 @@ int main(int argc, char** argv)
         std::generate(hostKeys.begin(), hostKeys.end(), [&]() { return dist(gen); });
     }
 
-    thrust::device_vector<KeyType> keys = hostKeys;
-    thrust::device_vector<ValueType> ordering(numKeys);
+    tracking_mr mem_tracker;        // Input memory
+    tracking_mr tmp_mem_tracker;    // Temporary memory
+
+    tracking_mr::vector<KeyType> keys(
+        hostKeys.begin(), hostKeys.end(), tracking_mr::allocator<KeyType>(&mem_tracker));
+    tracking_mr::vector<ValueType> ordering(
+        numKeys, 0, tracking_mr::allocator<ValueType>(&mem_tracker));
     thrust::sequence(ordering.begin(), ordering.end(), 0);
 
-    tracking_mr memory_tracker;
-    thrust::mr::allocator<KeyType, tracking_mr> alloc(&memory_tracker);
+    tracking_mr::allocator<KeyType> tmp_alloc(&tmp_mem_tracker);
 
     auto radixSortNormal = [&]() {
 #ifdef __HIP__
@@ -57,9 +61,11 @@ int main(int argc, char** argv)
 
     auto radixSortTracked = [&]() {
 #ifdef __HIP__
-        thrust::sort_by_key(thrust::hip::par(alloc), keys.begin(), keys.end(), ordering.begin());
+        thrust::sort_by_key(
+            thrust::hip::par(tmp_alloc), keys.begin(), keys.end(), ordering.begin());
 #else
-        thrust::sort_by_key(thrust::cuda::par(alloc), keys.begin(), keys.end(), ordering.begin());
+        thrust::sort_by_key(
+            thrust::cuda::par(tmp_alloc), keys.begin(), keys.end(), ordering.begin());
 #endif
     };
 
@@ -67,16 +73,17 @@ int main(int argc, char** argv)
     float timeRadixSort = timeGpu(radixSortNormal);    // to compare with memory tracking time
 
     // Re-initialize keys for tracked version
-    keys = hostKeys;
+    thrust::copy(hostKeys.begin(), hostKeys.end(), keys.begin());
     thrust::sequence(ordering.begin(), ordering.end(), 0);
 
     radixSortTracked();    // warmup
-    memory_tracker.reset();
+    tmp_mem_tracker.reset();
     float timeRadixSortTracked = timeGpu(radixSortTracked);
 
     // time is measured in ms
     float time_s = timeRadixSort / 1000;
-    memory_tracker.print_stats();
+    mem_tracker.print_stats<false>();
+    tmp_mem_tracker.print_stats<true>();
     std::size_t numBytesMoved = 2lu * numKeys * (sizeof(KeyType) + sizeof(ValueType));
     std::printf("radix sort normal time for %zu key-value pairs: %f s, bandwidth: %f MiB/s\n",
         numKeys, time_s, float(numBytesMoved) / time_s / (1024 * 1024));

--- a/parallel_algos/reduce.cu
+++ b/parallel_algos/reduce.cu
@@ -36,10 +36,13 @@ int main(int argc, char** argv)
         std::generate(hostValues.begin(), hostValues.end(), [&]() { return dist(gen); });
     }
 
-    thrust::device_vector<ValueType> values = hostValues;
+    tracking_mr mem_tracker;        // Input memory
+    tracking_mr tmp_mem_tracker;    // Temporary memory
 
-    tracking_mr memory_tracker;
-    thrust::mr::allocator<ValueType, tracking_mr> alloc(&memory_tracker);
+    tracking_mr::vector<ValueType> values(
+        hostValues.begin(), hostValues.end(), tracking_mr::allocator<ValueType>(&mem_tracker));
+
+    tracking_mr::allocator<ValueType> tmp_alloc(&tmp_mem_tracker);
 
     auto reduceNormal = [&]() {
 #ifdef __HIP__
@@ -51,9 +54,9 @@ int main(int argc, char** argv)
 
     auto reduceTracked = [&]() {
 #ifdef __HIP__
-        return thrust::reduce(thrust::hip::par(alloc), values.begin(), values.end());
+        return thrust::reduce(thrust::hip::par(tmp_alloc), values.begin(), values.end());
 #else
-        return thrust::reduce(thrust::cuda::par(alloc), values.begin(), values.end());
+        return thrust::reduce(thrust::cuda::par(tmp_alloc), values.begin(), values.end());
 #endif
     };
 
@@ -61,12 +64,13 @@ int main(int argc, char** argv)
     float timeReduce = timeGpu(reduceNormal);    // to compare with memory tracking time
 
     auto deviceResultTracked = reduceTracked();
-    memory_tracker.reset();
+    tmp_mem_tracker.reset();
     float timeReduceTracked = timeGpu(reduceTracked);
 
     // time is measured in ms
     float time_s = timeReduce / 1000;
-    memory_tracker.print_stats();
+    mem_tracker.print_stats<false>();
+    tmp_mem_tracker.print_stats<true>();
     std::size_t numBytesMoved = numValues * sizeof(ValueType);
     std::printf("reduction normal time for %zu values: %f s, bandwidth: %f MiB/s\n", numValues,
         time_s, float(numBytesMoved) / time_s / (1024 * 1024));

--- a/parallel_algos/scan.cu
+++ b/parallel_algos/scan.cu
@@ -35,19 +35,19 @@ int main(int argc, char** argv)
     std::vector<ValueType> hostValues(numValues);
     {
         std::mt19937 gen;
-        std::uniform_int_distribution<ValueType>
-
-            dist(0, std::numeric_limits<uint32_t>::max());
-        std::generate(hostValues.begin(),
-
-            hostValues.end(), [&]() { return dist(gen); });
+        std::uniform_int_distribution<ValueType> dist(0, std::numeric_limits<uint32_t>::max());
+        std::generate(hostValues.begin(), hostValues.end(), [&]() { return dist(gen); });
     }
 
-    thrust::device_vector<ValueType> values = hostValues;
-    thrust::device_vector<ValueType> scannedValues(numValues);
+    tracking_mr mem_tracker;        // Input memory
+    tracking_mr tmp_mem_tracker;    // Temporary memory
 
-    tracking_mr memory_tracker;
-    thrust::mr::allocator<ValueType, tracking_mr> alloc(&memory_tracker);
+    tracking_mr::vector<ValueType> values(
+        hostValues.begin(), hostValues.end(), tracking_mr::allocator<ValueType>(&mem_tracker));
+    tracking_mr::vector<ValueType> scannedValues(
+        numValues, 0, tracking_mr::allocator<ValueType>(&mem_tracker));
+
+    tracking_mr::allocator<ValueType> tmp_alloc(&tmp_mem_tracker);
 
     auto scanNormal = [&]() {
 #ifdef __HIP__
@@ -62,10 +62,10 @@ int main(int argc, char** argv)
     auto scanTracked = [&]() {
 #ifdef __HIP__
         thrust::exclusive_scan(
-            thrust::hip::par(alloc), values.begin(), values.end(), scannedValues.begin());
+            thrust::hip::par(tmp_alloc), values.begin(), values.end(), scannedValues.begin());
 #else
         thrust::exclusive_scan(
-            thrust::cuda::par(alloc), values.begin(), values.end(), scannedValues.begin());
+            thrust::cuda::par(tmp_alloc), values.begin(), values.end(), scannedValues.begin());
 #endif
     };
 
@@ -74,12 +74,13 @@ int main(int argc, char** argv)
     thrust::device_vector<ValueType> scannedValuesNormal = scannedValues;
 
     scanTracked();    // warmup
-    memory_tracker.reset();
+    tmp_mem_tracker.reset();
     float timeScanTracked = timeGpu(scanTracked);
 
     // time is measured in ms
     float time_s = timeScan / 1000;
-    memory_tracker.print_stats();
+    mem_tracker.print_stats<false>();
+    tmp_mem_tracker.print_stats<true>();
     std::size_t numBytesMoved = 2lu * numValues * sizeof(ValueType);
     std::printf("exclusive scan normal time for %zu values: %f s, bandwidth: %f MiB/s\n", numValues,
         time_s, float(numBytesMoved) / time_s / (1024 * 1024));


### PR DESCRIPTION
The memory statistics were currently printing only the temporary memory allocated within the algorithm itself and none of the input data. This adds the use of an allocator that tracks allocations of input/output data.

We need 2 allocators to track the memory allocated, cause we need to reset the counters after the warmup iteration.

Example on GH200:
```
$  ./reduce 30
Input/Output memory statistics:
  Total allocated: 8192.000000 MiB
  Peak allocated: 8192.000000 MiB
  Number of allocations: 1
Temporary memory statistics:
  Total allocated: 0.040535 MiB
  Peak allocated: 0.040535 MiB
  Number of allocations: 1
reduction normal time for 1073741824 values: 0.002429 s, bandwidth: 3372859.000000 MiB/s
reduction with memory tracking time for 1073741824 values: 0.002404 s, bandwidth: 3408198.250000 MiB/s
```