### PR TITLE
Merge `main` into `reframe-ci` branch

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,135 @@
+# Copyright (c) 2016 Thomas Heller
+# Copyright (c) 2016-2018 Hartmut Kaiser
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# This .clang-format file is a suggested configuration file for formatting
+# source code for the pika project.
+#
+# Here are a couple of guidelines of how to use this file.
+#
+# - You should use this file for creating an initial formatting for new files.
+#
+# - Please separate edits which are pure formatting into isolated commits
+#   keeping those distinct from edits changing any of the code.
+#
+# - Please do _not_ configure your editor to automatically format the source
+#   file while saving edits to disk
+# - Please do _not_ reformat a full source file without dire need.
+
+# PLEASE NOTE: This file requires clang-format V18.0
+
+---
+AccessModifierOffset: -4
+AlignAfterOpenBracket: DontAlign
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands: false
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Always
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+    AfterCaseLabel: true
+    AfterClass: true
+    AfterControlStatement: true
+    AfterEnum: true
+    AfterFunction: true
+    AfterNamespace: false
+    AfterStruct: true
+    AfterUnion: true
+    BeforeCatch: true
+    BeforeElse: true
+    IndentBraces: false
+BreakAfterAttributes: Leave
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: true
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: true
+BreakStringLiterals: true
+ColumnLimit: 100
+CommentPragmas: "///"
+CompactNamespaces: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+#ExperimentalAutoDetectBinPacking: true # Do weird reformatting
+FixNamespaceComments: true
+# ForEachMacros: ['']
+IncludeCategories:
+  - Regex:           '^<pika/config\.hpp>'
+    Priority:        1
+  - Regex:           '^<pika/config/defines\.hpp>'
+    Priority:        2
+  - Regex:           '^<pika/.*/config\.hpp>'
+    Priority:        3
+  - Regex:           '^<pika/.*\.hpp>'
+    Priority:        4
+  - Regex:           '^<pika/parallel/.*\.hpp>'
+    Priority:        5
+  - Regex:           '^<.*'
+    Priority:        6
+  - Regex:           '.*'
+    Priority:        7
+# IncludeIsMainRegex: ''
+IndentCaseLabels: false
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+IndentPPDirectives: AfterHash
+InsertBraces: false
+IntegerLiteralSeparator:
+  Binary: 4
+  Decimal: 0
+  Hex: 4
+KeepEmptyLinesAtTheStartOfBlocks: false
+Language: Cpp
+# MacroBlockBegin: ''
+# MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: All
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 20
+PointerAlignment: Left
+PPIndentWidth: 1
+ReflowComments: false
+QualifierAlignment: Right
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SortIncludes:    true
+SpaceAfterCStyleCast: true
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 4
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Cpp11
+TabWidth: 4
+UseTab: Never
+...

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,28 @@
+# Copyright (c) 2025 ETH Zurich
+
+name: Format
+
+on:
+  merge_group:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  format:
+    name: Check Code Formatting
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format-16
+
+      - name: Run clang-format
+        run: |
+          shopt -s globstar nullglob
+          clang-format-16 --dry-run --Werror **/*.{cpp,c,hpp,h,cu,cuh}

--- a/.gitlab/pipeline_reframe_ci.yml
+++ b/.gitlab/pipeline_reframe_ci.yml
@@ -2,8 +2,8 @@ include:
   - remote: 'https://gitlab.com/cscs-ci/recipes/-/raw/master/templates/v2/.ci-ext.yml'
 
 variables:
-  UENV_IMAGE: "prgenv-gnu/25.07-6.3.3:v5"
-  WITH_UENV_VIEW: "default-llvm-amdgpu"
+  UENV_IMAGE: "prgenv-gnu/25.07-6.3.3:v10"
+  WITH_UENV_VIEW: "default"
   SLURM_TIMELIMIT: "00:15:00"
   SLURM_JOB_NUM_NODES: 1
   SLURM_NTASKS: 1

--- a/.gitlab/pipeline_reframe_ci.yml
+++ b/.gitlab/pipeline_reframe_ci.yml
@@ -19,13 +19,12 @@ test_reframe:
     - cmake --version
     - hipcc --version || echo "HIP not found in PATH"
     # Install reframe
-    - git clone --depth 1 -b v4.8.4 https://github.com/reframe-hpc/reframe.git
-    - pushd reframe && ./bootstrap.sh && popd
+    - pip install reframe-hpc==4.8.4
     # Run gpu-benchmarks reframe tests
     - git clone --depth 1 https://github.com/eth-cscs/cscs-reframe-tests.git
     - cd cscs-reframe-tests
     - |
       for benchmark in checks/microbenchmarks/gpu/gpu_benchmarks/*.py; do
         echo "Running benchmark: $benchmark"
-        UENV=$UENV_IMAGE ../reframe/bin/reframe -C config/cscs.py -c $benchmark --system beverin:mi300 -r -v --keep-stage-files
+        UENV=$UENV_IMAGE reframe -C config/cscs.py -c $benchmark --system beverin:mi300 -r -v --keep-stage-files
       done

--- a/ROCm-core/managed-memory-pagefaults.cu
+++ b/ROCm-core/managed-memory-pagefaults.cu
@@ -22,141 +22,145 @@
 #include "../common/cuda_runtime.hpp"
 #include "../common/timing.cuh"
 
-__global__ void accessKernel(double *data, std::size_t n) {
-  auto i = blockIdx.x * blockDim.x + threadIdx.x;
-  if (i >= n)
-    return;
+__global__ void accessKernel(double* data, std::size_t n)
+{
+    auto i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n) return;
 
-  data[i] = i;
+    data[i] = i;
 }
 
-std::tuple<double, double> accessGpu(double *data, const std::size_t n) {
-  using clock = std::chrono::high_resolution_clock;
-  const auto start = clock::now();
+std::tuple<double, double> accessGpu(double* data, const std::size_t n)
+{
+    using clock = std::chrono::high_resolution_clock;
+    auto const start = clock::now();
 
-  constexpr unsigned threadsPerBlock = 1024;
-  unsigned blocks = (n + threadsPerBlock - 1) / threadsPerBlock;
-  accessKernel<<<blocks, threadsPerBlock>>>(data, n);
-  checkGpuErrors(cudaGetLastError());
-  checkGpuErrors(cudaDeviceSynchronize());
+    constexpr unsigned threadsPerBlock = 1024;
+    unsigned blocks = (n + threadsPerBlock - 1) / threadsPerBlock;
+    accessKernel<<<blocks, threadsPerBlock>>>(data, n);
+    checkGpuErrors(cudaGetLastError());
+    checkGpuErrors(cudaDeviceSynchronize());
 
-  const auto end = clock::now();
-  const double time = std::chrono::duration<double>(end - start).count();
-  const double bandwidth = n * sizeof(double) / 1e9 / time;
-  return {time, bandwidth};
+    auto const end = clock::now();
+    double const time = std::chrono::duration<double>(end - start).count();
+    double const bandwidth = n * sizeof(double) / 1e9 / time;
+    return {time, bandwidth};
 }
 
-[[gnu::noinline]] std::tuple<double, double> accessCpu(double *data,
-                                                       std::size_t n) {
-  using clock = std::chrono::high_resolution_clock;
-  const auto start = clock::now();
+[[gnu::noinline]] std::tuple<double, double> accessCpu(double* data, std::size_t n)
+{
+    using clock = std::chrono::high_resolution_clock;
+    auto const start = clock::now();
 
 #pragma omp parallel for simd nontemporal(data)
-  for (std::size_t i = 0; i < n; ++i)
-    data[i] = i;
+    for (std::size_t i = 0; i < n; ++i) data[i] = i;
 
-  const auto end = clock::now();
-  const double time = std::chrono::duration<double>(end - start).count();
-  const double bandwidth = n * sizeof(double) / 1e9 / time;
-  return {time, bandwidth};
+    auto const end = clock::now();
+    double const time = std::chrono::duration<double>(end - start).count();
+    double const bandwidth = n * sizeof(double) / 1e9 / time;
+    return {time, bandwidth};
 }
 
-int main(int argc, const char *argv[]) {
-  constexpr int runs = 3;
+int main(int argc, char const* argv[])
+{
+    constexpr int runs = 3;
 
-  std::size_t n = 1024ul * 1024 * 1024 * 1024;
-  std::size_t nAccessed = 1024ul * 1024 * 1024;
+    std::size_t n = 1024ul * 1024 * 1024 * 1024;
+    std::size_t nAccessed = 1024ul * 1024 * 1024;
 
 #ifdef __HIP_PLATFORM_AMD__
-  const char *xnack = std::getenv("HSA_XNACK");
-  if (!xnack || std::strcmp(xnack, "1")) {
-    std::fprintf(stderr,
-                 "WARNING: HSA_XNACK=1 not set!\n"
-                 "WARNING: This uses a reduced-size physical host allocation "
-                 "instead of pure-virtual 1TiB allocation.\n"
-                 "WARNING: Set the environment variable HSA_XNACK=1 to run the "
-                 "benchmark as expected.\n");
-    n = nAccessed;
-  }
+    char const* xnack = std::getenv("HSA_XNACK");
+    if (!xnack || std::strcmp(xnack, "1"))
+    {
+        std::fprintf(stderr,
+            "WARNING: HSA_XNACK=1 not set!\n"
+            "WARNING: This uses a reduced-size physical host allocation "
+            "instead of pure-virtual 1TiB allocation.\n"
+            "WARNING: Set the environment variable HSA_XNACK=1 to run the "
+            "benchmark as expected.\n");
+        n = nAccessed;
+    }
 #endif
 
 #ifndef _OPENMP
-  std::fprintf(
-      stderr,
-      "WARNING: compile this benchmark with OpenMP for proper CPU numbers\n");
+    std::fprintf(stderr, "WARNING: compile this benchmark with OpenMP for proper CPU numbers\n");
 #endif
 
-  std::printf("=== CPU ===\n");
-  for (int run = 0; run < runs; ++run) {
-    printf(" Run %d:\n", run + 1);
+    std::printf("=== CPU ===\n");
+    for (int run = 0; run < runs; ++run)
+    {
+        printf(" Run %d:\n", run + 1);
 
-    double *data;
-    checkGpuErrors(cudaMallocManaged(&data, n * sizeof(double)));
+        double* data;
+        checkGpuErrors(cudaMallocManaged(&data, n * sizeof(double)));
 
-    auto [firstAccessTime, firstAccessBandwidth] = accessCpu(data, nAccessed);
-    std::printf("  1st access took %7.5fs (BW: %6.1fGB/s)\n", firstAccessTime,
-                firstAccessBandwidth);
+        auto [firstAccessTime, firstAccessBandwidth] = accessCpu(data, nAccessed);
+        std::printf(
+            "  1st access took %7.5fs (BW: %6.1fGB/s)\n", firstAccessTime, firstAccessBandwidth);
 
-    auto [secondAccessTime, secondAccessBandwidth] = accessCpu(data, nAccessed);
-    std::printf("  2nd access took %7.5fs (BW: %6.1fGB/s)\n", secondAccessTime,
-                secondAccessBandwidth);
+        auto [secondAccessTime, secondAccessBandwidth] = accessCpu(data, nAccessed);
+        std::printf(
+            "  2nd access took %7.5fs (BW: %6.1fGB/s)\n", secondAccessTime, secondAccessBandwidth);
 
-    checkGpuErrors(cudaFree(data));
-  }
+        checkGpuErrors(cudaFree(data));
+    }
 
-  std::printf("=== GPU ===\n");
-  for (int run = 0; run < runs; ++run) {
-    printf(" Run %d:\n", run + 1);
+    std::printf("=== GPU ===\n");
+    for (int run = 0; run < runs; ++run)
+    {
+        printf(" Run %d:\n", run + 1);
 
-    double *data;
-    checkGpuErrors(cudaMallocManaged(&data, n * sizeof(double)));
+        double* data;
+        checkGpuErrors(cudaMallocManaged(&data, n * sizeof(double)));
 
-    auto [firstAccessTime, firstAccessBandwidth] = accessGpu(data, nAccessed);
-    std::printf("  1st access took %7.5fs (BW: %6.1fGB/s)\n", firstAccessTime,
-                firstAccessBandwidth);
+        auto [firstAccessTime, firstAccessBandwidth] = accessGpu(data, nAccessed);
+        std::printf(
+            "  1st access took %7.5fs (BW: %6.1fGB/s)\n", firstAccessTime, firstAccessBandwidth);
 
-    auto [secondAccessTime, secondAccessBandwidth] = accessGpu(data, nAccessed);
-    std::printf("  2nd access took %7.5fs (BW: %6.1fGB/s)\n", secondAccessTime,
-                secondAccessBandwidth);
+        auto [secondAccessTime, secondAccessBandwidth] = accessGpu(data, nAccessed);
+        std::printf(
+            "  2nd access took %7.5fs (BW: %6.1fGB/s)\n", secondAccessTime, secondAccessBandwidth);
 
-    checkGpuErrors(cudaFree(data));
-  }
+        checkGpuErrors(cudaFree(data));
+    }
 
-  std::printf("=== CPU, then GPU ===\n");
-  for (int run = 0; run < runs; ++run) {
-    printf(" Run %d:\n", run + 1);
+    std::printf("=== CPU, then GPU ===\n");
+    for (int run = 0; run < runs; ++run)
+    {
+        printf(" Run %d:\n", run + 1);
 
-    double *data;
-    checkGpuErrors(cudaMallocManaged(&data, n * sizeof(double)));
+        double* data;
+        checkGpuErrors(cudaMallocManaged(&data, n * sizeof(double)));
 
-    auto [firstAccessTime, firstAccessBandwidth] = accessCpu(data, nAccessed);
-    std::printf("  1st access took %7.5fs (BW: %6.1fGB/s)\n", firstAccessTime,
-                firstAccessBandwidth);
+        auto [firstAccessTime, firstAccessBandwidth] = accessCpu(data, nAccessed);
+        std::printf(
+            "  1st access took %7.5fs (BW: %6.1fGB/s)\n", firstAccessTime, firstAccessBandwidth);
 
-    auto [secondAccessTime, secondAccessBandwidth] = accessGpu(data, nAccessed);
-    std::printf("  2nd access took %7.5fs (BW: %6.1fGB/s)\n", secondAccessTime,
-                secondAccessBandwidth);
+        auto [secondAccessTime, secondAccessBandwidth] = accessGpu(data, nAccessed);
+        std::printf(
+            "  2nd access took %7.5fs (BW: %6.1fGB/s)\n", secondAccessTime, secondAccessBandwidth);
 
-    checkGpuErrors(cudaFree(data));
-  }
+        checkGpuErrors(cudaFree(data));
+    }
 
-  std::printf("=== GPU, then CPU ===\n");
-  for (int run = 0; run < runs; ++run) {
-    printf(" Run %d:\n", run + 1);
+    std::printf("=== GPU, then CPU ===\n");
+    for (int run = 0; run < runs; ++run)
+    {
+        printf(" Run %d:\n", run + 1);
 
-    double *data;
-    checkGpuErrors(cudaMallocManaged(&data, n * sizeof(double)));
+        double* data;
+        checkGpuErrors(cudaMallocManaged(&data, n * sizeof(double)));
 
-    auto [firstAccessTime, firstAccessBandwidth] = accessGpu(data, nAccessed);
-    std::printf("  1st access took %7.5fs (BW: %6.1fGB/s)\n", firstAccessTime,
-                firstAccessBandwidth);
+        auto [firstAccessTime, firstAccessBandwidth] = accessGpu(data, nAccessed);
+        std::printf(
+            "  1st access took %7.5fs (BW: %6.1fGB/s)\n", firstAccessTime, firstAccessBandwidth);
 
-    auto [secondAccessTime, secondAccessBandwidth] = accessCpu(data, nAccessed);
-    std::printf("  2nd access took %7.5fs (BW: %6.1fGB/s)\n", secondAccessTime,
-                secondAccessBandwidth);
+        auto [secondAccessTime, secondAccessBandwidth] = accessCpu(data, nAccessed);
+        std::printf(
+            "  2nd access took %7.5fs (BW: %6.1fGB/s)\n", secondAccessTime, secondAccessBandwidth);
 
-    checkGpuErrors(cudaFree(data));
-  }
+        checkGpuErrors(cudaFree(data));
+    }
 
-  return 0;
+    return 0;
 }

--- a/common/cub.hpp
+++ b/common/cub.hpp
@@ -11,12 +11,12 @@
 
 #ifdef __HIPCC__
 
-#include <hipcub/hipcub.hpp>
+# include <hipcub/hipcub.hpp>
 
 namespace cub = hipcub;
 
 #else
 
-#include <cub/cub.cuh>
+# include <cub/cub.cuh>
 
 #endif

--- a/common/cuda_runtime.hpp
+++ b/common/cuda_runtime.hpp
@@ -17,55 +17,55 @@
 
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
 
-#include <hip/hip_runtime.h>
+# include <hip/hip_runtime.h>
 
-#define cudaDeviceProp hipDeviceProp_t
-#define cudaDeviceSynchronize hipDeviceSynchronize
-#define cudaErrorInvalidValue hipErrorInvalidValue
-#define cudaError_t hipError_t
-#define cudaEventCreate hipEventCreate
-#define cudaEventDestroy hipEventDestroy
-#define cudaEventElapsedTime hipEventElapsedTime
-#define cudaEventRecord hipEventRecord
-#define cudaEventSynchronize hipEventSynchronize
-#define cudaEvent_t hipEvent_t
-#define cudaFree hipFree
-#define cudaFreeHost hipFreeHost
-#define cudaGetDevice hipGetDevice
-#define cudaGetDeviceCount hipGetDeviceCount
-#define cudaGetDeviceProperties hipGetDeviceProperties
-#define cudaGetErrorName hipGetErrorName
-#define cudaGetErrorString hipGetErrorString
-#define cudaGetLastError hipGetLastError
-#define cudaMalloc hipMalloc
-#define cudaMallocHost hipMallocHost
-#define cudaMallocManaged hipMallocManaged
-#define cudaMemAttachGlobal hipMemAttachGlobal
-#define cudaMemcpy hipMemcpy
-#define cudaMemcpyDeviceToDevice hipMemcpyDeviceToDevice
-#define cudaMemcpyDeviceToHost hipMemcpyDeviceToHost
-#define cudaMemcpyFromSymbol hipMemcpyFromSymbol
-#define cudaMemcpyHostToDevice hipMemcpyHostToDevice
-#define cudaMemcpyToSymbol hipMemcpyToSymbol
-#define cudaMemoryTypeDevice hipMemoryTypeDevice
-#define cudaMemoryTypeManaged hipMemoryTypeManaged
-#define cudaMemset hipMemset
-#define cudaPointerAttributes hipPointerAttribute_t
-#define cudaPointerGetAttributes hipPointerGetAttributes
-#define cudaSetDevice hipSetDevice
-#define cudaStreamDefault hipStreamDefault
-#define cudaStreamCreate hipStreamCreate
-#define cudaStreamDestroy hipStreamDestroy
-#define cudaStreamSynchronize hipStreamSynchronize
-#define cudaStream_t hipStream_t
-#define cudaSuccess hipSuccess
+# define cudaDeviceProp hipDeviceProp_t
+# define cudaDeviceSynchronize hipDeviceSynchronize
+# define cudaErrorInvalidValue hipErrorInvalidValue
+# define cudaError_t hipError_t
+# define cudaEventCreate hipEventCreate
+# define cudaEventDestroy hipEventDestroy
+# define cudaEventElapsedTime hipEventElapsedTime
+# define cudaEventRecord hipEventRecord
+# define cudaEventSynchronize hipEventSynchronize
+# define cudaEvent_t hipEvent_t
+# define cudaFree hipFree
+# define cudaFreeHost hipFreeHost
+# define cudaGetDevice hipGetDevice
+# define cudaGetDeviceCount hipGetDeviceCount
+# define cudaGetDeviceProperties hipGetDeviceProperties
+# define cudaGetErrorName hipGetErrorName
+# define cudaGetErrorString hipGetErrorString
+# define cudaGetLastError hipGetLastError
+# define cudaMalloc hipMalloc
+# define cudaMallocHost hipMallocHost
+# define cudaMallocManaged hipMallocManaged
+# define cudaMemAttachGlobal hipMemAttachGlobal
+# define cudaMemcpy hipMemcpy
+# define cudaMemcpyDeviceToDevice hipMemcpyDeviceToDevice
+# define cudaMemcpyDeviceToHost hipMemcpyDeviceToHost
+# define cudaMemcpyFromSymbol hipMemcpyFromSymbol
+# define cudaMemcpyHostToDevice hipMemcpyHostToDevice
+# define cudaMemcpyToSymbol hipMemcpyToSymbol
+# define cudaMemoryTypeDevice hipMemoryTypeDevice
+# define cudaMemoryTypeManaged hipMemoryTypeManaged
+# define cudaMemset hipMemset
+# define cudaPointerAttributes hipPointerAttribute_t
+# define cudaPointerGetAttributes hipPointerGetAttributes
+# define cudaSetDevice hipSetDevice
+# define cudaStreamDefault hipStreamDefault
+# define cudaStreamCreate hipStreamCreate
+# define cudaStreamDestroy hipStreamDestroy
+# define cudaStreamSynchronize hipStreamSynchronize
+# define cudaStream_t hipStream_t
+# define cudaSuccess hipSuccess
 
-#define GPU_SYMBOL HIP_SYMBOL
+# define GPU_SYMBOL HIP_SYMBOL
 
 #else
 
-#include <cuda_runtime.h>
+# include <cuda_runtime.h>
 
-#define GPU_SYMBOL(x) x
+# define GPU_SYMBOL(x) x
 
 #endif

--- a/common/timing.cuh
+++ b/common/timing.cuh
@@ -18,14 +18,14 @@
 #include <chrono>
 #include "./cuda_runtime.hpp"
 
-inline void checkErr(cudaError_t err, const char* filename, int lineno, const char* funcName)
+inline void checkErr(cudaError_t err, char const* filename, int lineno, char const* funcName)
 {
     if (err != cudaSuccess)
     {
-        const char* errName = cudaGetErrorName(err);
-        const char* errStr  = cudaGetErrorString(err);
-        fprintf(stderr, "CUDA Error at %s:%d. Function %s returned err %d: %s - %s\n", filename, lineno, funcName, err,
-                errName, errStr);
+        char const* errName = cudaGetErrorName(err);
+        char const* errStr = cudaGetErrorString(err);
+        fprintf(stderr, "CUDA Error at %s:%d. Function %s returned err %d: %s - %s\n", filename,
+            lineno, funcName, err, errName, errStr);
         exit(EXIT_FAILURE);
     }
 }
@@ -33,7 +33,7 @@ inline void checkErr(cudaError_t err, const char* filename, int lineno, const ch
 #define checkGpuErrors(errcode) checkErr((errcode), __FILE__, __LINE__, #errcode)
 
 //! @brief time a generic unary function
-template<class F>
+template <class F>
 float timeGpu(F&& f)
 {
     cudaEvent_t start, stop;
@@ -56,7 +56,7 @@ float timeGpu(F&& f)
     return t0;
 }
 
-template<class F>
+template <class F>
 float timeCpu(F&& f)
 {
     auto t0 = std::chrono::high_resolution_clock::now();

--- a/fft/fft_bench.cpp
+++ b/fft/fft_bench.cpp
@@ -14,114 +14,111 @@
 // of samples to measure.
 // Returns the mean time of execution measured on GPU.
 template <typename T>
-float bench_fft(std::vector<int> sizes, int n_batch, int n_sample) {
-  using complex_t = typename gpu::fft::ComplexType<T>::type;
+float bench_fft(std::vector<int> sizes, int n_batch, int n_sample)
+{
+    using complex_t = typename gpu::fft::ComplexType<T>::type;
 
-  const int batch_size =
-      std::accumulate(sizes.begin(), sizes.end(), 1, std::multiplies<int>());
-  std::vector<complex_t> input_host(n_batch * batch_size);
+    int const batch_size = std::accumulate(sizes.begin(), sizes.end(), 1, std::multiplies<int>());
+    std::vector<complex_t> input_host(n_batch * batch_size);
 
-  complex_t *input_device;
-  complex_t *output_device;
+    complex_t* input_device;
+    complex_t* output_device;
 
-  gpu::api::malloc((void **)&input_device,
-                   input_host.size() * sizeof(complex_t));
-  gpu::api::malloc((void **)&output_device,
-                   input_host.size() * sizeof(complex_t));
+    gpu::api::malloc((void**) &input_device, input_host.size() * sizeof(complex_t));
+    gpu::api::malloc((void**) &output_device, input_host.size() * sizeof(complex_t));
 
-  std::minstd_rand rand_gen(42);
-  std::uniform_real_distribution<T> rand_dist(-3, 3);
+    std::minstd_rand rand_gen(42);
+    std::uniform_real_distribution<T> rand_dist(-3, 3);
 
-  // initialize input to avoid potential performance impact of nonsensical
-  // input to sin / cos functions in FFT
-  for (auto &val : input_host) {
-    val.x = rand_dist(rand_gen);
-    val.y = rand_dist(rand_gen);
-  }
+    // initialize input to avoid potential performance impact of nonsensical
+    // input to sin / cos functions in FFT
+    for (auto& val : input_host)
+    {
+        val.x = rand_dist(rand_gen);
+        val.y = rand_dist(rand_gen);
+    }
 
-  gpu::api::memcpy(input_device, input_host.data(),
-                   input_host.size() * sizeof(complex_t),
-                   gpu::api::flag::MemcpyHostToDevice);
+    gpu::api::memcpy(input_device, input_host.data(), input_host.size() * sizeof(complex_t),
+        gpu::api::flag::MemcpyHostToDevice);
 
-  gpu::fft::HandleType plan;
+    gpu::fft::HandleType plan;
 
-  gpu::fft::plan_many(&plan, sizes.size(), sizes.data(), nullptr, 1, batch_size,
-                      nullptr, 1, batch_size,
-                      gpu ::fft::TransformType::ComplexToComplex<T>::value,
-                      n_batch);
+    gpu::fft::plan_many(&plan, sizes.size(), sizes.data(), nullptr, 1, batch_size, nullptr, 1,
+        batch_size, gpu ::fft::TransformType::ComplexToComplex<T>::value, n_batch);
 
-  gpu::api::EventType event_start, event_end;
+    gpu::api::EventType event_start, event_end;
 
-  gpu::api::event_create(&event_start);
-  gpu::api::event_create(&event_end);
+    gpu::api::event_create(&event_start);
+    gpu::api::event_create(&event_end);
 
-  // run once to warm up
-  gpu::fft::execute(plan, input_device, output_device,
-                    gpu::fft::TransformDirection::Backward);
+    // run once to warm up
+    gpu::fft::execute(plan, input_device, output_device, gpu::fft::TransformDirection::Backward);
 
-  // compute n_sample FFTs
-  gpu::api::event_record(event_start);
-  for (int i = 0; i < n_sample; ++i) {
-    gpu::fft::execute(plan, input_device, output_device,
-                      gpu::fft::TransformDirection::Backward);
-  }
-  gpu::api::event_record(event_end);
-  float time = 0;
-  gpu::api::event_synchronize(event_end);
-  gpu::api::event_elapsed_time(&time, event_start, event_end);
+    // compute n_sample FFTs
+    gpu::api::event_record(event_start);
+    for (int i = 0; i < n_sample; ++i)
+    {
+        gpu::fft::execute(
+            plan, input_device, output_device, gpu::fft::TransformDirection::Backward);
+    }
+    gpu::api::event_record(event_end);
+    float time = 0;
+    gpu::api::event_synchronize(event_end);
+    gpu::api::event_elapsed_time(&time, event_start, event_end);
 
-  std::ignore = gpu::api::event_destroy(event_start);
-  std::ignore = gpu::api::event_destroy(event_end);
-  std::ignore = gpu::fft::destroy(plan);
-  std::ignore = gpu::api::free(input_device);
-  std::ignore = gpu::api::free(output_device);
+    std::ignore = gpu::api::event_destroy(event_start);
+    std::ignore = gpu::api::event_destroy(event_end);
+    std::ignore = gpu::fft::destroy(plan);
+    std::ignore = gpu::api::free(input_device);
+    std::ignore = gpu::api::free(output_device);
 
-  return time / n_sample;
+    return time / n_sample;
 }
 
-int main(int argc, char **argv) {
-  std::vector<int> sizes;
-  std::string precision;
-  int n_sample = 1;
-  int n_batch = 1;
+int main(int argc, char** argv)
+{
+    std::vector<int> sizes;
+    std::string precision;
+    int n_sample = 1;
+    int n_batch = 1;
 
-  CLI::App app{"FFT benchmark"};
-  app.add_option("-n", sizes,
-                 "FFT size. Between 1 and 3 space-separated values for 1D, 2D or 3D FFTs.")
-      ->required()
-      ->expected(1, 3)
-      ->check(CLI::NonNegativeNumber);
-  app.add_option("-s", n_sample, "Number of samples for time measurement")
-      ->check(CLI::NonNegativeNumber)
-      ->default_val(10);
-  app.add_option("-b", n_batch, "FFT batch size")
-      ->check(CLI::NonNegativeNumber)
-      ->default_val(1);
-  app.add_option("-p", precision, "Precision. \"single\" or \"double\"")
-      ->check(CLI::IsMember({"single", "double"}))
-      ->default_val("double");
+    CLI::App app{"FFT benchmark"};
+    app.add_option(
+           "-n", sizes, "FFT size. Between 1 and 3 space-separated values for 1D, 2D or 3D FFTs.")
+        ->required()
+        ->expected(1, 3)
+        ->check(CLI::NonNegativeNumber);
+    app.add_option("-s", n_sample, "Number of samples for time measurement")
+        ->check(CLI::NonNegativeNumber)
+        ->default_val(10);
+    app.add_option("-b", n_batch, "FFT batch size")->check(CLI::NonNegativeNumber)->default_val(1);
+    app.add_option("-p", precision, "Precision. \"single\" or \"double\"")
+        ->check(CLI::IsMember({"single", "double"}))
+        ->default_val("double");
 
-  try {
-    app.parse(argc, argv);
-  } catch (const CLI::ParseError &e) {
-    return app.exit(e);
-  }
+    try
+    {
+        app.parse(argc, argv);
+    }
+    catch (const CLI::ParseError& e)
+    {
+        return app.exit(e);
+    }
 
-  const auto time = precision == "single"
-                        ? bench_fft<float>(sizes, n_batch, n_sample)
-                        : bench_fft<double>(sizes, n_batch, n_sample);
+    auto const time = precision == "single" ? bench_fft<float>(sizes, n_batch, n_sample) :
+                                              bench_fft<double>(sizes, n_batch, n_sample);
 
-  std::cout << "==== FFT Benchmark ====" << std::endl;
+    std::cout << "==== FFT Benchmark ====" << std::endl;
 
-  std::cout << "Parameters: size = (" << sizes[0];
-  if (sizes.size() >= 2) std::cout << ", " << sizes[1];
-  if (sizes.size() >= 3) std::cout << ", " << sizes[2];
-  std::cout << ")";
+    std::cout << "Parameters: size = (" << sizes[0];
+    if (sizes.size() >= 2) std::cout << ", " << sizes[1];
+    if (sizes.size() >= 3) std::cout << ", " << sizes[2];
+    std::cout << ")";
 
-  std::cout << ", batch size = " << n_batch << ", samples = " << n_sample
-            << ", precision = " << precision << std::endl;
+    std::cout << ", batch size = " << n_batch << ", samples = " << n_sample
+              << ", precision = " << precision << std::endl;
 
-  std::cout << "Mean time [ms]: " << time << std::endl;
+    std::cout << "Mean time [ms]: " << time << std::endl;
 
-  return 0;
+    return 0;
 }

--- a/fft/gpu_fft_api.hpp
+++ b/fft/gpu_fft_api.hpp
@@ -1,238 +1,253 @@
 #pragma once
 
 #if defined(FFT_BENCH_CUDA)
-#include <cufft.h>
-#define GPU_FFT_PREFIX(val) cufft##val
+# include <cufft.h>
+# define GPU_FFT_PREFIX(val) cufft##val
 
 #else
 
-#if __has_include(<hipfft/hipfft.h>)
-#include <hipfft/hipfft.h>
-#else
-#include <hipfft.h>
-#endif
+# if __has_include(<hipfft/hipfft.h>)
+#  include <hipfft/hipfft.h>
+# else
+#  include <hipfft.h>
+# endif
 
-#define GPU_FFT_PREFIX(val) hipfft##val
+# define GPU_FFT_PREFIX(val) hipfft##val
 #endif
 
 #include <stdexcept>
 #include <utility>
 
-namespace gpu {
-namespace fft {
+namespace gpu { namespace fft {
 
-// ==================================
-// Types
-// ==================================
-using ResultType = GPU_FFT_PREFIX(Result);
-using HandleType = GPU_FFT_PREFIX(Handle);
-using ComplexFloatType = GPU_FFT_PREFIX(Complex);
-using ComplexDoubleType = GPU_FFT_PREFIX(DoubleComplex);
+        // ==================================
+        // Types
+        // ==================================
+        using ResultType = GPU_FFT_PREFIX(Result);
+        using HandleType = GPU_FFT_PREFIX(Handle);
+        using ComplexFloatType = GPU_FFT_PREFIX(Complex);
+        using ComplexDoubleType = GPU_FFT_PREFIX(DoubleComplex);
 
-// Complex type selector
-template <typename T>
-struct ComplexType;
+        // Complex type selector
+        template <typename T>
+        struct ComplexType;
 
-template <>
-struct ComplexType<double> {
-  using type = ComplexDoubleType;
-};
+        template <>
+        struct ComplexType<double>
+        {
+            using type = ComplexDoubleType;
+        };
 
-template <>
-struct ComplexType<float> {
-  using type = ComplexFloatType;
-};
+        template <>
+        struct ComplexType<float>
+        {
+            using type = ComplexFloatType;
+        };
 
-// ==================================
-// Transform types
-// ==================================
-namespace TransformDirection {
+        // ==================================
+        // Transform types
+        // ==================================
+        namespace TransformDirection {
 #ifdef FFT_BENCH_CUDA
-constexpr auto Forward = CUFFT_FORWARD;
-constexpr auto Backward = CUFFT_INVERSE;
+            constexpr auto Forward = CUFFT_FORWARD;
+            constexpr auto Backward = CUFFT_INVERSE;
 #else
-constexpr auto Forward = HIPFFT_FORWARD;
-constexpr auto Backward = HIPFFT_BACKWARD;
+            constexpr auto Forward = HIPFFT_FORWARD;
+            constexpr auto Backward = HIPFFT_BACKWARD;
 #endif
-}  // namespace TransformDirection
+        }    // namespace TransformDirection
 
-// ==================================
-// Transform types
-// ==================================
-namespace TransformType {
+        // ==================================
+        // Transform types
+        // ==================================
+        namespace TransformType {
 #ifdef FFT_BENCH_CUDA
-constexpr auto R2C = CUFFT_R2C;
-constexpr auto C2R = CUFFT_C2R;
-constexpr auto C2C = CUFFT_C2C;
-constexpr auto D2Z = CUFFT_D2Z;
-constexpr auto Z2D = CUFFT_Z2D;
-constexpr auto Z2Z = CUFFT_Z2Z;
+            constexpr auto R2C = CUFFT_R2C;
+            constexpr auto C2R = CUFFT_C2R;
+            constexpr auto C2C = CUFFT_C2C;
+            constexpr auto D2Z = CUFFT_D2Z;
+            constexpr auto Z2D = CUFFT_Z2D;
+            constexpr auto Z2Z = CUFFT_Z2Z;
 #else
-constexpr auto R2C = HIPFFT_R2C;
-constexpr auto C2R = HIPFFT_C2R;
-constexpr auto C2C = HIPFFT_C2C;
-constexpr auto D2Z = HIPFFT_D2Z;
-constexpr auto Z2D = HIPFFT_Z2D;
-constexpr auto Z2Z = HIPFFT_Z2Z;
+            constexpr auto R2C = HIPFFT_R2C;
+            constexpr auto C2R = HIPFFT_C2R;
+            constexpr auto C2C = HIPFFT_C2C;
+            constexpr auto D2Z = HIPFFT_D2Z;
+            constexpr auto Z2D = HIPFFT_Z2D;
+            constexpr auto Z2Z = HIPFFT_Z2Z;
 #endif
 
-// Transform type selector
-template <typename T>
-struct ComplexToComplex;
+            // Transform type selector
+            template <typename T>
+            struct ComplexToComplex;
 
-template <>
-struct ComplexToComplex<double> {
-  constexpr static auto value = Z2Z;
-};
+            template <>
+            struct ComplexToComplex<double>
+            {
+                constexpr static auto value = Z2Z;
+            };
 
-template <>
-struct ComplexToComplex<float> {
-  constexpr static auto value = C2C;
-};
+            template <>
+            struct ComplexToComplex<float>
+            {
+                constexpr static auto value = C2C;
+            };
 
-// Transform type selector
-template <typename T>
-struct RealToComplex;
+            // Transform type selector
+            template <typename T>
+            struct RealToComplex;
 
-template <>
-struct RealToComplex<double> {
-  constexpr static auto value = D2Z;
-};
+            template <>
+            struct RealToComplex<double>
+            {
+                constexpr static auto value = D2Z;
+            };
 
-template <>
-struct RealToComplex<float> {
-  constexpr static auto value = R2C;
-};
+            template <>
+            struct RealToComplex<float>
+            {
+                constexpr static auto value = R2C;
+            };
 
-// Transform type selector
-template <typename T>
-struct ComplexToReal;
+            // Transform type selector
+            template <typename T>
+            struct ComplexToReal;
 
-template <>
-struct ComplexToReal<double> {
-  constexpr static auto value = Z2D;
-};
+            template <>
+            struct ComplexToReal<double>
+            {
+                constexpr static auto value = Z2D;
+            };
 
-template <>
-struct ComplexToReal<float> {
-  constexpr static auto value = C2R;
-};
-}  // namespace TransformType
+            template <>
+            struct ComplexToReal<float>
+            {
+                constexpr static auto value = C2R;
+            };
+        }    // namespace TransformType
 
-// ==================================
-// Result values
-// ==================================
-namespace result {
+        // ==================================
+        // Result values
+        // ==================================
+        namespace result {
 #ifdef FFT_BENCH_CUDA
-constexpr auto Success = CUFFT_SUCCESS;
+            constexpr auto Success = CUFFT_SUCCESS;
 #else
-constexpr auto Success = HIPFFT_SUCCESS;
+            constexpr auto Success = HIPFFT_SUCCESS;
 #endif
-}  // namespace result
+        }    // namespace result
 
-// ==================================
-// Error check functions
-// ==================================
-inline auto check_result(ResultType error) -> void {
-  if (error != result::Success) {
-    throw std::runtime_error("GPU FFT error");
-  }
-}
+        // ==================================
+        // Error check functions
+        // ==================================
+        inline auto check_result(ResultType error) -> void
+        {
+            if (error != result::Success) { throw std::runtime_error("GPU FFT error"); }
+        }
 
-// ==================================
-// Execution function overload
-// ==================================
-inline auto execute(HandleType &plan, const ComplexDoubleType *iData,
-                    double *oData) -> void {
-  check_result(GPU_FFT_PREFIX(ExecZ2D)(
-      plan, const_cast<ComplexDoubleType *>(iData), oData));
-}
+        // ==================================
+        // Execution function overload
+        // ==================================
+        inline auto execute(HandleType& plan, ComplexDoubleType const* iData, double* oData) -> void
+        {
+            check_result(
+                GPU_FFT_PREFIX(ExecZ2D)(plan, const_cast<ComplexDoubleType*>(iData), oData));
+        }
 
-inline auto execute(HandleType &plan, const ComplexFloatType *iData,
-                    float *oData) -> void {
-  check_result(GPU_FFT_PREFIX(ExecC2R)(
-      plan, const_cast<ComplexFloatType *>(iData), oData));
-}
+        inline auto execute(HandleType& plan, ComplexFloatType const* iData, float* oData) -> void
+        {
+            check_result(
+                GPU_FFT_PREFIX(ExecC2R)(plan, const_cast<ComplexFloatType*>(iData), oData));
+        }
 
-inline auto execute(HandleType &plan, const double *iData,
-                    ComplexDoubleType *oData) -> void {
-  check_result(
-      GPU_FFT_PREFIX(ExecD2Z)(plan, const_cast<double *>(iData), oData));
-}
+        inline auto execute(HandleType& plan, double const* iData, ComplexDoubleType* oData) -> void
+        {
+            check_result(GPU_FFT_PREFIX(ExecD2Z)(plan, const_cast<double*>(iData), oData));
+        }
 
-inline auto execute(HandleType &plan, const float *iData,
-                    ComplexFloatType *oData) -> void {
-  check_result(
-      GPU_FFT_PREFIX(ExecR2C)(plan, const_cast<float *>(iData), oData));
-}
+        inline auto execute(HandleType& plan, float const* iData, ComplexFloatType* oData) -> void
+        {
+            check_result(GPU_FFT_PREFIX(ExecR2C)(plan, const_cast<float*>(iData), oData));
+        }
 
-inline auto execute(HandleType &plan, const ComplexDoubleType *iData,
-                    ComplexDoubleType *oData, int direction) -> void {
-  check_result(GPU_FFT_PREFIX(ExecZ2Z)(
-      plan, const_cast<ComplexDoubleType *>(iData), oData, direction));
-}
+        inline auto execute(HandleType& plan, ComplexDoubleType const* iData,
+            ComplexDoubleType* oData, int direction) -> void
+        {
+            check_result(GPU_FFT_PREFIX(ExecZ2Z)(
+                plan, const_cast<ComplexDoubleType*>(iData), oData, direction));
+        }
 
-inline auto execute(HandleType &plan, const ComplexFloatType *iData,
-                    ComplexFloatType *oData, int direction) -> void {
-  check_result(GPU_FFT_PREFIX(ExecC2C)(
-      plan, const_cast<ComplexFloatType *>(iData), oData, direction));
-}
+        inline auto execute(HandleType& plan, ComplexFloatType const* iData,
+            ComplexFloatType* oData, int direction) -> void
+        {
+            check_result(GPU_FFT_PREFIX(ExecC2C)(
+                plan, const_cast<ComplexFloatType*>(iData), oData, direction));
+        }
 
-// ==================================
-// Forwarding functions of to GPU API
-// ==================================
+        // ==================================
+        // Forwarding functions of to GPU API
+        // ==================================
 
-template <typename... ARGS>
-inline auto create(ARGS &&...args) -> void {
-  check_result(GPU_FFT_PREFIX(Create)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto create(ARGS&&... args) -> void
+        {
+            check_result(GPU_FFT_PREFIX(Create)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto make_plan_many(ARGS &&...args) -> void {
-  check_result(GPU_FFT_PREFIX(MakePlanMany)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto make_plan_many(ARGS&&... args) -> void
+        {
+            check_result(GPU_FFT_PREFIX(MakePlanMany)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto plan_many(ARGS &&...args) -> void {
-  check_result(GPU_FFT_PREFIX(PlanMany)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto plan_many(ARGS&&... args) -> void
+        {
+            check_result(GPU_FFT_PREFIX(PlanMany)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto plan_1d(ARGS &&...args) -> void {
-  check_result(GPU_FFT_PREFIX(Plan1d)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto plan_1d(ARGS&&... args) -> void
+        {
+            check_result(GPU_FFT_PREFIX(Plan1d)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto plan_2d(ARGS &&...args) -> void {
-  check_result(GPU_FFT_PREFIX(Plan2d)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto plan_2d(ARGS&&... args) -> void
+        {
+            check_result(GPU_FFT_PREFIX(Plan2d)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto plan_3d(ARGS &&...args) -> void {
-  check_result(GPU_FFT_PREFIX(Plan3d)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto plan_3d(ARGS&&... args) -> void
+        {
+            check_result(GPU_FFT_PREFIX(Plan3d)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto set_work_area(ARGS &&...args) -> void {
-  check_result(GPU_FFT_PREFIX(SetWorkArea)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto set_work_area(ARGS&&... args) -> void
+        {
+            check_result(GPU_FFT_PREFIX(SetWorkArea)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto destroy(ARGS &&...args) -> ResultType {
-  return GPU_FFT_PREFIX(Destroy)(std::forward<ARGS>(args)...);
-}
+        template <typename... ARGS>
+        inline auto destroy(ARGS&&... args) -> ResultType
+        {
+            return GPU_FFT_PREFIX(Destroy)(std::forward<ARGS>(args)...);
+        }
 
-template <typename... ARGS>
-inline auto set_stream(ARGS &&...args) -> void {
-  check_result(GPU_FFT_PREFIX(SetStream)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto set_stream(ARGS&&... args) -> void
+        {
+            check_result(GPU_FFT_PREFIX(SetStream)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto set_auto_allocation(ARGS &&...args) -> void {
-  check_result(GPU_FFT_PREFIX(SetAutoAllocation)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto set_auto_allocation(ARGS&&... args) -> void
+        {
+            check_result(GPU_FFT_PREFIX(SetAutoAllocation)(std::forward<ARGS>(args)...));
+        }
 
-}  // namespace fft
-}  // namespace gpu
+}}    // namespace gpu::fft
 
 #undef GPU_FFT_PREFIX

--- a/fft/gpu_runtime_api.hpp
+++ b/fft/gpu_runtime_api.hpp
@@ -1,223 +1,235 @@
 #pragma once
 
 #if defined(FFT_BENCH_CUDA)
-#include <cuda_runtime_api.h>
-#define GPU_PREFIX(val) cuda##val
+# include <cuda_runtime_api.h>
+# define GPU_PREFIX(val) cuda##val
 
 #else
-#include <hip/hip_runtime_api.h>
-#define GPU_PREFIX(val) hip##val
+# include <hip/hip_runtime_api.h>
+# define GPU_PREFIX(val) hip##val
 #endif
 
 #include <stdexcept>
 #include <utility>
 
-namespace gpu {
-namespace api {
+namespace gpu { namespace api {
 
-using StatusType = GPU_PREFIX(Error_t);
-using StreamType = GPU_PREFIX(Stream_t);
-using EventType = GPU_PREFIX(Event_t);
+        using StatusType = GPU_PREFIX(Error_t);
+        using StreamType = GPU_PREFIX(Stream_t);
+        using EventType = GPU_PREFIX(Event_t);
 
-namespace status {
-// error / return values
-constexpr StatusType Success = GPU_PREFIX(Success);
-constexpr StatusType ErrorMemoryAllocation = GPU_PREFIX(ErrorMemoryAllocation);
-constexpr StatusType ErrorLaunchOutOfResources =
-    GPU_PREFIX(ErrorLaunchOutOfResources);
-constexpr StatusType ErrorInvalidValue = GPU_PREFIX(ErrorInvalidValue);
-constexpr StatusType ErrorInvalidResourceHandle =
-    GPU_PREFIX(ErrorInvalidResourceHandle);
-constexpr StatusType ErrorInvalidDevice = GPU_PREFIX(ErrorInvalidDevice);
-constexpr StatusType ErrorInvalidMemcpyDirection =
-    GPU_PREFIX(ErrorInvalidMemcpyDirection);
-constexpr StatusType ErrorInvalidDevicePointer =
-    GPU_PREFIX(ErrorInvalidDevicePointer);
-constexpr StatusType ErrorInitializationError =
-    GPU_PREFIX(ErrorInitializationError);
-constexpr StatusType ErrorNoDevice = GPU_PREFIX(ErrorNoDevice);
-constexpr StatusType ErrorNotReady = GPU_PREFIX(ErrorNotReady);
-constexpr StatusType ErrorUnknown = GPU_PREFIX(ErrorUnknown);
-constexpr StatusType ErrorPeerAccessNotEnabled =
-    GPU_PREFIX(ErrorPeerAccessNotEnabled);
-constexpr StatusType ErrorPeerAccessAlreadyEnabled =
-    GPU_PREFIX(ErrorPeerAccessAlreadyEnabled);
-constexpr StatusType ErrorHostMemoryAlreadyRegistered =
-    GPU_PREFIX(ErrorHostMemoryAlreadyRegistered);
-constexpr StatusType ErrorHostMemoryNotRegistered =
-    GPU_PREFIX(ErrorHostMemoryNotRegistered);
-constexpr StatusType ErrorUnsupportedLimit = GPU_PREFIX(ErrorUnsupportedLimit);
-}  // namespace status
+        namespace status {
+            // error / return values
+            constexpr StatusType Success = GPU_PREFIX(Success);
+            constexpr StatusType ErrorMemoryAllocation = GPU_PREFIX(ErrorMemoryAllocation);
+            constexpr StatusType ErrorLaunchOutOfResources = GPU_PREFIX(ErrorLaunchOutOfResources);
+            constexpr StatusType ErrorInvalidValue = GPU_PREFIX(ErrorInvalidValue);
+            constexpr StatusType ErrorInvalidResourceHandle =
+                GPU_PREFIX(ErrorInvalidResourceHandle);
+            constexpr StatusType ErrorInvalidDevice = GPU_PREFIX(ErrorInvalidDevice);
+            constexpr StatusType ErrorInvalidMemcpyDirection =
+                GPU_PREFIX(ErrorInvalidMemcpyDirection);
+            constexpr StatusType ErrorInvalidDevicePointer = GPU_PREFIX(ErrorInvalidDevicePointer);
+            constexpr StatusType ErrorInitializationError = GPU_PREFIX(ErrorInitializationError);
+            constexpr StatusType ErrorNoDevice = GPU_PREFIX(ErrorNoDevice);
+            constexpr StatusType ErrorNotReady = GPU_PREFIX(ErrorNotReady);
+            constexpr StatusType ErrorUnknown = GPU_PREFIX(ErrorUnknown);
+            constexpr StatusType ErrorPeerAccessNotEnabled = GPU_PREFIX(ErrorPeerAccessNotEnabled);
+            constexpr StatusType ErrorPeerAccessAlreadyEnabled =
+                GPU_PREFIX(ErrorPeerAccessAlreadyEnabled);
+            constexpr StatusType ErrorHostMemoryAlreadyRegistered =
+                GPU_PREFIX(ErrorHostMemoryAlreadyRegistered);
+            constexpr StatusType ErrorHostMemoryNotRegistered =
+                GPU_PREFIX(ErrorHostMemoryNotRegistered);
+            constexpr StatusType ErrorUnsupportedLimit = GPU_PREFIX(ErrorUnsupportedLimit);
+        }    // namespace status
 
-// flags to pass to GPU API
-namespace flag {
-constexpr auto StreamDefault = GPU_PREFIX(StreamDefault);
-constexpr auto StreamNonBlocking = GPU_PREFIX(StreamNonBlocking);
+        // flags to pass to GPU API
+        namespace flag {
+            constexpr auto StreamDefault = GPU_PREFIX(StreamDefault);
+            constexpr auto StreamNonBlocking = GPU_PREFIX(StreamNonBlocking);
 
-constexpr auto MemcpyDefault = GPU_PREFIX(MemcpyDefault);
-constexpr auto MemcpyHostToDevice = GPU_PREFIX(MemcpyHostToDevice);
-constexpr auto MemcpyDeviceToHost = GPU_PREFIX(MemcpyDeviceToHost);
-constexpr auto MemcpyDeviceToDevice = GPU_PREFIX(MemcpyDeviceToDevice);
+            constexpr auto MemcpyDefault = GPU_PREFIX(MemcpyDefault);
+            constexpr auto MemcpyHostToDevice = GPU_PREFIX(MemcpyHostToDevice);
+            constexpr auto MemcpyDeviceToHost = GPU_PREFIX(MemcpyDeviceToHost);
+            constexpr auto MemcpyDeviceToDevice = GPU_PREFIX(MemcpyDeviceToDevice);
 
-constexpr auto EventDefault = GPU_PREFIX(EventDefault);
-constexpr auto EventBlockingSync = GPU_PREFIX(EventBlockingSync);
-constexpr auto EventDisableTiming = GPU_PREFIX(EventDisableTiming);
-constexpr auto EventInterprocess = GPU_PREFIX(EventInterprocess);
-}  // namespace flag
+            constexpr auto EventDefault = GPU_PREFIX(EventDefault);
+            constexpr auto EventBlockingSync = GPU_PREFIX(EventBlockingSync);
+            constexpr auto EventDisableTiming = GPU_PREFIX(EventDisableTiming);
+            constexpr auto EventInterprocess = GPU_PREFIX(EventInterprocess);
+        }    // namespace flag
 
-// ==================================
-// Error check functions
-// ==================================
-inline auto get_error_string(StatusType error) -> const char * {
-  return GPU_PREFIX(GetErrorString)(error);
-}
+        // ==================================
+        // Error check functions
+        // ==================================
+        inline auto get_error_string(StatusType error) -> char const*
+        {
+            return GPU_PREFIX(GetErrorString)(error);
+        }
 
-inline auto check_status(StatusType error) -> void {
-  if (error != status::Success) {
-    throw std::runtime_error(get_error_string(error));
-  }
-}
+        inline auto check_status(StatusType error) -> void
+        {
+            if (error != status::Success) { throw std::runtime_error(get_error_string(error)); }
+        }
 
-// ===================================================
-// Forwarding functions of to GPU API with error check
-// ===================================================
-template <typename... ARGS>
-inline auto host_register(ARGS &&...args) -> void {
-  check_status(GPU_PREFIX(HostRegister)(std::forward<ARGS>(args)...));
-}
+        // ===================================================
+        // Forwarding functions of to GPU API with error check
+        // ===================================================
+        template <typename... ARGS>
+        inline auto host_register(ARGS&&... args) -> void
+        {
+            check_status(GPU_PREFIX(HostRegister)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto host_unregister(ARGS &&...args) -> void {
-  check_status(GPU_PREFIX(HostUnregister)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto host_unregister(ARGS&&... args) -> void
+        {
+            check_status(GPU_PREFIX(HostUnregister)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto stream_create_with_flags(ARGS &&...args) -> void {
-  check_status(GPU_PREFIX(StreamCreateWithFlags)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto stream_create_with_flags(ARGS&&... args) -> void
+        {
+            check_status(GPU_PREFIX(StreamCreateWithFlags)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto stream_wait_event(ARGS &&...args) -> void {
-  check_status(GPU_PREFIX(StreamWaitEvent)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto stream_wait_event(ARGS&&... args) -> void
+        {
+            check_status(GPU_PREFIX(StreamWaitEvent)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto event_create(ARGS &&...args) -> void {
-  check_status(GPU_PREFIX(EventCreate)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto event_create(ARGS&&... args) -> void
+        {
+            check_status(GPU_PREFIX(EventCreate)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto event_create_with_flags(ARGS &&...args) -> void {
-  check_status(GPU_PREFIX(EventCreateWithFlags)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto event_create_with_flags(ARGS&&... args) -> void
+        {
+            check_status(GPU_PREFIX(EventCreateWithFlags)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto event_record(ARGS &&...args) -> void {
-  check_status(GPU_PREFIX(EventRecord)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto event_record(ARGS&&... args) -> void
+        {
+            check_status(GPU_PREFIX(EventRecord)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto event_synchronize(ARGS &&...args) -> void {
-  check_status(GPU_PREFIX(EventSynchronize)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto event_synchronize(ARGS&&... args) -> void
+        {
+            check_status(GPU_PREFIX(EventSynchronize)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto event_elapsed_time(ARGS &&...args) -> void {
-  check_status(GPU_PREFIX(EventElapsedTime)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto event_elapsed_time(ARGS&&... args) -> void
+        {
+            check_status(GPU_PREFIX(EventElapsedTime)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto malloc(ARGS &&...args) -> void {
-  check_status(GPU_PREFIX(Malloc)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto malloc(ARGS&&... args) -> void
+        {
+            check_status(GPU_PREFIX(Malloc)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto memcpy(ARGS &&...args) -> void {
-  check_status(GPU_PREFIX(Memcpy)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto memcpy(ARGS&&... args) -> void
+        {
+            check_status(GPU_PREFIX(Memcpy)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto memcpy_2d(ARGS &&...args) -> void {
-  check_status(GPU_PREFIX(Memcpy2D)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto memcpy_2d(ARGS&&... args) -> void
+        {
+            check_status(GPU_PREFIX(Memcpy2D)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto memcpy_async(ARGS &&...args) -> void {
-  check_status(GPU_PREFIX(MemcpyAsync)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto memcpy_async(ARGS&&... args) -> void
+        {
+            check_status(GPU_PREFIX(MemcpyAsync)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto memcpy_2d_async(ARGS &&...args) -> void {
-  check_status(GPU_PREFIX(Memcpy2DAsync)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto memcpy_2d_async(ARGS&&... args) -> void
+        {
+            check_status(GPU_PREFIX(Memcpy2DAsync)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto get_device(ARGS &&...args) -> void {
-  check_status(GPU_PREFIX(GetDevice)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto get_device(ARGS&&... args) -> void
+        {
+            check_status(GPU_PREFIX(GetDevice)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto set_device(ARGS &&...args) -> void {
-  check_status(GPU_PREFIX(SetDevice)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto set_device(ARGS&&... args) -> void
+        {
+            check_status(GPU_PREFIX(SetDevice)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto get_device_count(ARGS &&...args) -> void {
-  check_status(GPU_PREFIX(GetDeviceCount)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto get_device_count(ARGS&&... args) -> void
+        {
+            check_status(GPU_PREFIX(GetDeviceCount)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto stream_synchronize(ARGS &&...args) -> void {
-  check_status(GPU_PREFIX(StreamSynchronize)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto stream_synchronize(ARGS&&... args) -> void
+        {
+            check_status(GPU_PREFIX(StreamSynchronize)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto memset_async(ARGS &&...args) -> void {
-  check_status(GPU_PREFIX(MemsetAsync)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto memset_async(ARGS&&... args) -> void
+        {
+            check_status(GPU_PREFIX(MemsetAsync)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto memset_2d_async(ARGS &&...args) -> void {
-  check_status(GPU_PREFIX(Memset2DAsync)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto memset_2d_async(ARGS&&... args) -> void
+        {
+            check_status(GPU_PREFIX(Memset2DAsync)(std::forward<ARGS>(args)...));
+        }
 
-template <typename... ARGS>
-inline auto get_device_properties(ARGS &&...args) -> void {
-  check_status(GPU_PREFIX(GetDeviceProperties)(std::forward<ARGS>(args)...));
-}
+        template <typename... ARGS>
+        inline auto get_device_properties(ARGS&&... args) -> void
+        {
+            check_status(GPU_PREFIX(GetDeviceProperties)(std::forward<ARGS>(args)...));
+        }
 
-inline auto device_synchronize() -> void {
-  check_status(GPU_PREFIX(DeviceSynchronize)());
-}
+        inline auto device_synchronize() -> void { check_status(GPU_PREFIX(DeviceSynchronize)()); }
 
-inline auto check_last_error() -> void {
-  check_status(GPU_PREFIX(GetLastError)());
-}
+        inline auto check_last_error() -> void { check_status(GPU_PREFIX(GetLastError)()); }
 
-// =====================================================
-// Forwarding functions of to GPU API with status return
-// =====================================================
+        // =====================================================
+        // Forwarding functions of to GPU API with status return
+        // =====================================================
 
-inline auto get_last_error() -> StatusType {
-  return GPU_PREFIX(GetLastError)();
-}
+        inline auto get_last_error() -> StatusType { return GPU_PREFIX(GetLastError)(); }
 
-template <typename... ARGS>
-inline auto free(ARGS &&...args) -> StatusType {
-  return GPU_PREFIX(Free)(std::forward<ARGS>(args)...);
-}
+        template <typename... ARGS>
+        inline auto free(ARGS&&... args) -> StatusType
+        {
+            return GPU_PREFIX(Free)(std::forward<ARGS>(args)...);
+        }
 
-template <typename... ARGS>
-inline auto stream_destroy(ARGS &&...args) -> StatusType {
-  return GPU_PREFIX(StreamDestroy)(std::forward<ARGS>(args)...);
-}
+        template <typename... ARGS>
+        inline auto stream_destroy(ARGS&&... args) -> StatusType
+        {
+            return GPU_PREFIX(StreamDestroy)(std::forward<ARGS>(args)...);
+        }
 
-template <typename... ARGS>
-inline auto event_destroy(ARGS &&...args) -> StatusType {
-  return GPU_PREFIX(EventDestroy)(std::forward<ARGS>(args)...);
-}
+        template <typename... ARGS>
+        inline auto event_destroy(ARGS&&... args) -> StatusType
+        {
+            return GPU_PREFIX(EventDestroy)(std::forward<ARGS>(args)...);
+        }
 
-}  // namespace api
-}  // namespace gpu
+}}    // namespace gpu::api
 
 #undef GPU_PREFIX

--- a/parallel_algos/memory_tracking_allocator.cuh
+++ b/parallel_algos/memory_tracking_allocator.cuh
@@ -9,12 +9,12 @@
 
 #pragma once
 
-#include <cstdio>
 #include <atomic>
-#include <thrust/device_malloc.h>
+#include <cstdio>
 #include <thrust/device_free.h>
-#include <thrust/mr/memory_resource.h>
+#include <thrust/device_malloc.h>
 #include <thrust/mr/allocator.h>
+#include <thrust/mr/memory_resource.h>
 
 class tracking_mr final : public thrust::mr::memory_resource<>
 {
@@ -35,7 +35,8 @@ public:
         num_allocs.fetch_add(1);
 
         std::size_t peak = peak_bytes.load();
-        while (current > peak && !peak_bytes.compare_exchange_weak(peak, current));
+        while (current > peak && !peak_bytes.compare_exchange_weak(peak, current))
+            ;
 
         return static_cast<void*>(ptr.get());
     }

--- a/parallel_algos/radix-sort.cu
+++ b/parallel_algos/radix-sort.cu
@@ -74,13 +74,16 @@ int main(int argc, char** argv)
     memory_tracker.reset();
     float timeRadixSortTracked = timeGpu(radixSortTracked);
 
+    // time is measured in ms
+    float time_s = timeRadixSort / 1000;
     memory_tracker.print_stats();
     std::size_t numBytesMoved = 2lu * numKeys * (sizeof(KeyType) + sizeof(ValueType));
     std::printf("radix sort normal time for %zu key-value pairs: %f s, bandwidth: %f MiB/s\n",
-        numKeys, timeRadixSort / 1000, float(numBytesMoved) / timeRadixSort / 1000);
+        numKeys, time_s, float(numBytesMoved) / time_s / (1024 * 1024));
+    time_s = timeRadixSortTracked / 1000;
     std::printf(
         "radix sort with memory tracking time for %zu key-value pairs: %f s, bandwidth: %f MiB/s\n",
-        numKeys, timeRadixSortTracked / 1000, float(numBytesMoved) / timeRadixSortTracked / 1000);
+        numKeys, time_s, float(numBytesMoved) / time_s / (1024 * 1024));
 
     return 0;
 }

--- a/parallel_algos/radix-sort.cu
+++ b/parallel_algos/radix-sort.cu
@@ -27,17 +27,17 @@
 
 int main(int argc, char** argv)
 {
-    using KeyType   = uint64_t;
+    using KeyType = uint64_t;
     using ValueType = uint32_t;
 
-    int power           = argc > 1 ? std::stoi(argv[1]) : 25;
+    int power = argc > 1 ? std::stoi(argv[1]) : 25;
     std::size_t numKeys = 1lu << power;
 
     std::vector<KeyType> hostKeys(numKeys);
     {
         std::mt19937 gen;
         std::uniform_int_distribution<KeyType> dist(0, std::numeric_limits<KeyType>::max());
-        std::generate(hostKeys.begin(), hostKeys.end(), [&](){ return dist(gen); });
+        std::generate(hostKeys.begin(), hostKeys.end(), [&]() { return dist(gen); });
     }
 
     thrust::device_vector<KeyType> keys = hostKeys;
@@ -47,8 +47,7 @@ int main(int argc, char** argv)
     tracking_mr memory_tracker;
     thrust::mr::allocator<KeyType, tracking_mr> alloc(&memory_tracker);
 
-    auto radixSortNormal = [&]()
-    {
+    auto radixSortNormal = [&]() {
 #ifdef __HIP__
         thrust::sort_by_key(thrust::hip::par, keys.begin(), keys.end(), ordering.begin());
 #else
@@ -56,8 +55,7 @@ int main(int argc, char** argv)
 #endif
     };
 
-    auto radixSortTracked = [&]()
-    {
+    auto radixSortTracked = [&]() {
 #ifdef __HIP__
         thrust::sort_by_key(thrust::hip::par(alloc), keys.begin(), keys.end(), ordering.begin());
 #else
@@ -65,23 +63,24 @@ int main(int argc, char** argv)
 #endif
     };
 
-    radixSortNormal(); // warmup
+    radixSortNormal();                                 // warmup
     float timeRadixSort = timeGpu(radixSortNormal);    // to compare with memory tracking time
 
     // Re-initialize keys for tracked version
     keys = hostKeys;
     thrust::sequence(ordering.begin(), ordering.end(), 0);
 
-    radixSortTracked(); // warmup
+    radixSortTracked();    // warmup
     memory_tracker.reset();
     float timeRadixSortTracked = timeGpu(radixSortTracked);
 
     memory_tracker.print_stats();
     std::size_t numBytesMoved = 2lu * numKeys * (sizeof(KeyType) + sizeof(ValueType));
     std::printf("radix sort normal time for %zu key-value pairs: %f s, bandwidth: %f MiB/s\n",
-                numKeys, timeRadixSort / 1000, float(numBytesMoved) / timeRadixSort / 1000);
-    std::printf("radix sort with memory tracking time for %zu key-value pairs: %f s, bandwidth: %f MiB/s\n",
-                numKeys, timeRadixSortTracked / 1000, float(numBytesMoved) / timeRadixSortTracked / 1000);
+        numKeys, timeRadixSort / 1000, float(numBytesMoved) / timeRadixSort / 1000);
+    std::printf(
+        "radix sort with memory tracking time for %zu key-value pairs: %f s, bandwidth: %f MiB/s\n",
+        numKeys, timeRadixSortTracked / 1000, float(numBytesMoved) / timeRadixSortTracked / 1000);
 
     return 0;
 }

--- a/parallel_algos/reduce.cu
+++ b/parallel_algos/reduce.cu
@@ -64,12 +64,15 @@ int main(int argc, char** argv)
     memory_tracker.reset();
     float timeReduceTracked = timeGpu(reduceTracked);
 
+    // time is measured in ms
+    float time_s = timeReduce / 1000;
     memory_tracker.print_stats();
     std::size_t numBytesMoved = numValues * sizeof(ValueType);
     std::printf("reduction normal time for %zu values: %f s, bandwidth: %f MiB/s\n", numValues,
-        timeReduce / 1000, float(numBytesMoved) / timeReduce / 1000);
+        time_s, float(numBytesMoved) / time_s / (1024 * 1024));
+    time_s = timeReduceTracked / 1000;
     std::printf("reduction with memory tracking time for %zu values: %f s, bandwidth: %f MiB/s\n",
-        numValues, timeReduceTracked / 1000, float(numBytesMoved) / timeReduceTracked / 1000);
+        numValues, time_s, float(numBytesMoved) / time_s / (1024 * 1024));
 
     if (power <= 25)
     {

--- a/parallel_algos/reduce.cu
+++ b/parallel_algos/reduce.cu
@@ -26,14 +26,14 @@ int main(int argc, char** argv)
 {
     using ValueType = uint64_t;
 
-    int power             = argc > 1 ? std::stoi(argv[1]) : 25;
+    int power = argc > 1 ? std::stoi(argv[1]) : 25;
     std::size_t numValues = 1lu << power;
 
     std::vector<ValueType> hostValues(numValues);
     {
         std::mt19937 gen;
         std::uniform_int_distribution<ValueType> dist(0, std::numeric_limits<uint32_t>::max());
-        std::generate(hostValues.begin(), hostValues.end(), [&](){ return dist(gen); });
+        std::generate(hostValues.begin(), hostValues.end(), [&]() { return dist(gen); });
     }
 
     thrust::device_vector<ValueType> values = hostValues;
@@ -41,8 +41,7 @@ int main(int argc, char** argv)
     tracking_mr memory_tracker;
     thrust::mr::allocator<ValueType, tracking_mr> alloc(&memory_tracker);
 
-    auto reduceNormal = [&]()
-    {
+    auto reduceNormal = [&]() {
 #ifdef __HIP__
         return thrust::reduce(thrust::hip::par, values.begin(), values.end());
 #else
@@ -50,8 +49,7 @@ int main(int argc, char** argv)
 #endif
     };
 
-    auto reduceTracked = [&]()
-    {
+    auto reduceTracked = [&]() {
 #ifdef __HIP__
         return thrust::reduce(thrust::hip::par(alloc), values.begin(), values.end());
 #else
@@ -68,16 +66,17 @@ int main(int argc, char** argv)
 
     memory_tracker.print_stats();
     std::size_t numBytesMoved = numValues * sizeof(ValueType);
-    std::printf("reduction normal time for %zu values: %f s, bandwidth: %f MiB/s\n",
-                numValues, timeReduce / 1000, float(numBytesMoved) / timeReduce / 1000);
+    std::printf("reduction normal time for %zu values: %f s, bandwidth: %f MiB/s\n", numValues,
+        timeReduce / 1000, float(numBytesMoved) / timeReduce / 1000);
     std::printf("reduction with memory tracking time for %zu values: %f s, bandwidth: %f MiB/s\n",
-            numValues, timeReduceTracked / 1000, float(numBytesMoved) / timeReduceTracked / 1000);
+        numValues, timeReduceTracked / 1000, float(numBytesMoved) / timeReduceTracked / 1000);
 
     if (power <= 25)
     {
         auto hostResult = std::accumulate(hostValues.begin(), hostValues.end(), ValueType(0));
         std::printf("CPU matches GPU: %s\n", (deviceResult == hostResult ? "PASS" : "FAIL"));
-        std::printf("GPU normal matches GPU with tracked memory: %s\n", (deviceResult == deviceResultTracked ? "PASS" : "FAIL"));
+        std::printf("GPU normal matches GPU with tracked memory: %s\n",
+            (deviceResult == deviceResultTracked ? "PASS" : "FAIL"));
     }
 
     return 0;

--- a/parallel_algos/scan.cu
+++ b/parallel_algos/scan.cu
@@ -77,13 +77,16 @@ int main(int argc, char** argv)
     memory_tracker.reset();
     float timeScanTracked = timeGpu(scanTracked);
 
+    // time is measured in ms
+    float time_s = timeScan / 1000;
     memory_tracker.print_stats();
     std::size_t numBytesMoved = 2lu * numValues * sizeof(ValueType);
     std::printf("exclusive scan normal time for %zu values: %f s, bandwidth: %f MiB/s\n", numValues,
-        timeScan / 1000, float(numBytesMoved) / timeScan / 1000);
+        time_s, float(numBytesMoved) / time_s / (1024 * 1024));
+    time_s = timeScanTracked / 1000;
     std::printf(
         "exclusive scan with memory tracking time for %zu values: %f s, bandwidth: %f MiB/s\n",
-        numValues, timeScanTracked / 1000, float(numBytesMoved) / timeScanTracked / 1000);
+        numValues, time_s, float(numBytesMoved) / time_s / (1024 * 1024));
 
     if (power <= 25)
     {

--- a/parallel_algos/scan.cu
+++ b/parallel_algos/scan.cu
@@ -29,14 +29,18 @@ int main(int argc, char** argv)
 {
     using ValueType = uint64_t;
 
-    int power             = argc > 1 ? std::stoi(argv[1]) : 25;
+    int power = argc > 1 ? std::stoi(argv[1]) : 25;
     std::size_t numValues = 1lu << power;
 
     std::vector<ValueType> hostValues(numValues);
     {
         std::mt19937 gen;
-        std::uniform_int_distribution<ValueType> dist(0, std::numeric_limits<uint32_t>::max());
-        std::generate(hostValues.begin(), hostValues.end(), [&](){ return dist(gen); });
+        std::uniform_int_distribution<ValueType>
+
+            dist(0, std::numeric_limits<uint32_t>::max());
+        std::generate(hostValues.begin(),
+
+            hostValues.end(), [&]() { return dist(gen); });
     }
 
     thrust::device_vector<ValueType> values = hostValues;
@@ -45,45 +49,50 @@ int main(int argc, char** argv)
     tracking_mr memory_tracker;
     thrust::mr::allocator<ValueType, tracking_mr> alloc(&memory_tracker);
 
-    auto scanNormal = [&]()
-    {
+    auto scanNormal = [&]() {
 #ifdef __HIP__
-        thrust::exclusive_scan(thrust::hip::par, values.begin(), values.end(), scannedValues.begin());
+        thrust::exclusive_scan(
+            thrust::hip::par, values.begin(), values.end(), scannedValues.begin());
 #else
-        thrust::exclusive_scan(thrust::cuda::par, values.begin(), values.end(), scannedValues.begin());
+        thrust::exclusive_scan(
+            thrust::cuda::par, values.begin(), values.end(), scannedValues.begin());
 #endif
     };
 
-    auto scanTracked = [&]()
-    {
+    auto scanTracked = [&]() {
 #ifdef __HIP__
-        thrust::exclusive_scan(thrust::hip::par(alloc), values.begin(), values.end(), scannedValues.begin());
+        thrust::exclusive_scan(
+            thrust::hip::par(alloc), values.begin(), values.end(), scannedValues.begin());
 #else
-        thrust::exclusive_scan(thrust::cuda::par(alloc), values.begin(), values.end(), scannedValues.begin());
+        thrust::exclusive_scan(
+            thrust::cuda::par(alloc), values.begin(), values.end(), scannedValues.begin());
 #endif
     };
 
-    scanNormal(); // warmup
+    scanNormal();    // warmup
     float timeScan = timeGpu(scanNormal);
     thrust::device_vector<ValueType> scannedValuesNormal = scannedValues;
 
-    scanTracked(); // warmup
+    scanTracked();    // warmup
     memory_tracker.reset();
     float timeScanTracked = timeGpu(scanTracked);
 
     memory_tracker.print_stats();
     std::size_t numBytesMoved = 2lu * numValues * sizeof(ValueType);
-    std::printf("exclusive scan normal time for %zu values: %f s, bandwidth: %f MiB/s\n",
-                numValues, timeScan / 1000, float(numBytesMoved) / timeScan / 1000);
-    std::printf("exclusive scan with memory tracking time for %zu values: %f s, bandwidth: %f MiB/s\n",
-                numValues, timeScanTracked / 1000, float(numBytesMoved) / timeScanTracked / 1000);
+    std::printf("exclusive scan normal time for %zu values: %f s, bandwidth: %f MiB/s\n", numValues,
+        timeScan / 1000, float(numBytesMoved) / timeScan / 1000);
+    std::printf(
+        "exclusive scan with memory tracking time for %zu values: %f s, bandwidth: %f MiB/s\n",
+        numValues, timeScanTracked / 1000, float(numBytesMoved) / timeScanTracked / 1000);
 
     if (power <= 25)
     {
         std::vector<ValueType> hostScan(numValues);
         std::exclusive_scan(hostValues.begin(), hostValues.end(), hostScan.begin(), ValueType(0));
-        std::printf("GPU matches CPU: %s\n", (hostScan.back() == scannedValues.back() ? "PASS" : "FAIL"));
-        std::printf("GPU normal matches GPU with tracked memory: %s\n", (scannedValuesNormal.back() == scannedValues.back() ? "PASS" : "FAIL"));
+        std::printf(
+            "GPU matches CPU: %s\n", (hostScan.back() == scannedValues.back() ? "PASS" : "FAIL"));
+        std::printf("GPU normal matches GPU with tracked memory: %s\n",
+            (scannedValuesNormal.back() == scannedValues.back() ? "PASS" : "FAIL"));
     }
 
     return 0;

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -1,0 +1,20 @@
+#!/bin/bash
+# To install this hook, run from the repository root:
+#   ln -sf ../../tools/pre-commit .git/hooks/pre-commit
+
+cxxfiles=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(c|cpp|hpp|h|cu|cuh)$')
+
+if [ -z "$cxxfiles" ]; then
+    exit 0
+fi
+
+failed=0
+for file in $cxxfiles; do
+    if ! clang-format-16 --dry-run --Werror "$file" 2>/dev/null; then
+        echo "$file formatted, please review.."
+        clang-format-16 -i "$file"
+        failed=1
+    fi
+done
+
+exit $failed


### PR DESCRIPTION
Clang-format changes and bandwidth unit fixed.

This PR also modifies how reframe is installed, we now use the reframe pip package instead of bootstrapping. When the extraordinary maintenance happened, the uenv v5 was not available anymore, so we used v10 but this didn't allow bootstrapping because of missing libxml2 and libxslt, it's cleaner now.